### PR TITLE
Proposing five new rules to enforce

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,8 +34,7 @@ module.exports = {
 
     "max-len": "off",                 // TBD
     "no-confusing-arrow": "off",      // TBD --fixable
-    "no-console": "off",              // TBD
-    "no-else-return": "off",          // TBD --fixable
+    "no-console": "warn",             // Team Preference
     "no-mixed-operators": "off",      // TBD
     "no-param-reassign": "off",       // TBD
     "no-plusplus": "off",             // TBD
@@ -43,18 +42,15 @@ module.exports = {
     "no-restricted-globals": "off",   // TBD
     "no-shadow": "off",               // TBD
     "no-underscore-dangle": "off",    // TBD
-    "no-unused-vars": ["error", {     // Team Preference
-      "args": "none"
-    }],
     "no-use-before-define": "off",    // Team Preference
-    "object-curly-newline": "off",    // TBD --fixable
+    "object-curly-newline": "off",    // Team Preference
     "prefer-arrow-callback": "off",   // TBD --fixable
     "prefer-destructuring": "off",    // Team Preference
     "prefer-rest-params": "off",      // TBD
     "radix": "off",                   // Team Preference
 
     "react/forbid-prop-types": "off",             // TBD
-    "react/jsx-boolean-value": "off",             // TBD --fixable
+    "react/jsx-boolean-value": ["error", "always"],
     "react/jsx-closing-bracket-location": "off",  // TBD --fixable
     "react/jsx-no-bind": "off",                   // TBD
     "react/jsx-no-target-blank": "off",           // TBD
@@ -64,7 +60,6 @@ module.exports = {
     "react/no-unescaped-entities": ["error", {    // Team Preference
       "forbid": [">", "}"]
     }],
-    "react/no-unused-prop-types": "off",          // TBD
     "react/prefer-stateless-function": "off",     // Team Preference
     "react/require-default-props": "off",         // TBD
     "react/self-closing-comp": "off",             // TBD

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-arcadia",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Arcadia Power's ESLint Configuration",
   "main": "index.js",
   "author": "Arcadia Power Engineering",


### PR DESCRIPTION
### What
This PR proposes the enforcement of five ESLint rules.

#### [no-else-return](https://eslint.org/docs/rules/no-else-return) - enforce
> If an `if` block contains a `return` statement, the `else` block becomes unnecessary. Its contents can be placed outside of the block.

#### [no-console](https://eslint.org/docs/rules/no-console) - warn
> It’s considered a best practice to avoid using methods on `console`. Such messages are considered to be for debugging purposes and therefore not suitable to ship to the client.

#### [no-unused-vars](https://eslint.org/docs/rules/no-unused-vars) - enforce
> This rule is aimed at eliminating unused variables, functions, *and parameters* of functions.

#### [react/jsx-boolean-value](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-boolean-value.md) - enforce
> When using a boolean attribute in JSX, you can set the attribute value to true or omit the value. This rule will enforce one or the other to keep consistency in your code.

#### [react/no-unused-prop-types](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md) - enforce
> Warns you if you have defined a prop type but it is never being used anywhere.

### Why
Linting will hopefully make our code easier to read, easier to maintain, and less prone to errors. But some rules can be more of a burden than actually helpful. Let's decide as a team what we want to enforce.

### Test Coverage
Linting is a form of testing.

### Risks and Deploy Considerations
Now that our linting config is shared across repos, we'll need to make sure to fix all the things in all the places. I have a branch to fix Jabiru and then I'll run it through Shrike and Admin Panel.

I'm not sure of the order of operations here, once approved. Maybe fix the things in the external repos and then merge this in?
