### PR TITLE
Rule arrow-parens "as-needed"

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,10 @@ module.exports = {
     "node": true
   },
   "rules": {
-    "arrow-body-style": "off",            // Team Preference
-    "arrow-parens": ["error", "always"],  // Team Preference
+    "arrow-body-style": "off",                  // Team Preference
+    "arrow-parens": ["error", "as-needed", {    // Team Preference
+        "requireForBlockBody": true
+    }],
     "class-methods-use-this": "off",      // TBD
     "comma-dangle": ["error", {           // Team Preference
       "objects": "always-multiline"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-arcadia",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Arcadia Power's ESLint Configuration",
   "main": "index.js",
   "author": "Arcadia Power Engineering",


### PR DESCRIPTION
After the last team check-up, it was decided to stop requiring parenthesis for arrow function parameters in all cases. Instead, only require them when necessary (multiple parameters) or when the function has a block body.

https://eslint.org/docs/rules/arrow-parens.html#as-needed

Required for ArcadiaPower/jabiru#924
Required for ArcadiaPower/osprey#317