### PR TITLE
Rule `no-else-return` off

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ module.exports = {
     "max-len": "off",                 // TBD
     "no-confusing-arrow": "off",      // TBD --fixable
     "no-console": "warn",             // Team Preference
+    "no-else-return": "off",          // Team Preference
     "no-mixed-operators": "off",      // TBD
     "no-param-reassign": "off",       // TBD
     "no-plusplus": "off",             // TBD

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-arcadia",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Arcadia Power's ESLint Configuration",
   "main": "index.js",
   "author": "Arcadia Power Engineering",


### PR DESCRIPTION
As decided by the FE Team, we will turn off the ESLint rule [`no-else-return`](https://eslint.org/docs/rules/no-else-return).

### Now
```jsx
if (utilityCharge > totalCharge) {
  return <label>You saved: <span className={styles.savings}>{convertMoney(utilityCharge - totalCharge)}</span></label>;
} else if (utilityCharge < totalCharge) {
  return <label>{convertMoney(totalCharge - utilityCharge)}</label>;
} else {  // allowed
  return null;
}
```

### Then
```jsx
if (utilityCharge > totalCharge) {
  return <label>You saved: <span className={styles.savings}>{convertMoney(utilityCharge - totalCharge)}</span></label>;
} else if (utilityCharge < totalCharge) {
  return <label>{convertMoney(totalCharge - utilityCharge)}</label>;
}

return null;
```

I don't think we need to retrofit all the existing cases of this in Jabiru and Osprey, just a preference going forward.