### PR TITLE
Rule comma-dangle "always-multiline" for arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,9 +10,13 @@ module.exports = {
     "arrow-parens": ["error", "as-needed", {    // Team Preference
         "requireForBlockBody": true
     }],
-    "class-methods-use-this": "off",      // TBD
-    "comma-dangle": ["error", {           // Team Preference
-      "objects": "always-multiline"
+    "class-methods-use-this": "off",    // TBD
+    "comma-dangle": ["error", {         // Team Preference
+      "arrays": "always-multiline",
+      "objects": "always-multiline",
+      "imports": "never",
+      "exports": "never",
+      "functions": "ignore"
     }],
     "consistent-return": "off",         // TBD
     "default-case": "off",              // TBD

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-arcadia",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Arcadia Power's ESLint Configuration",
   "main": "index.js",
   "author": "Arcadia Power Engineering",


### PR DESCRIPTION
After the last team check-up, it was decided to require a dangling comma for multiline arrays.

https://eslint.org/docs/rules/comma-dangle#options

#### Before
```javascript
const body = pick(params, [
  'panels',
  'paymentMethodId',
  'utilityAccountId'
]);
```

#### After
```javascript
const body = pick(params, [
  'panels',
  'paymentMethodId',
  'utilityAccountId',
]);
```

Required for ArcadiaPower/jabiru#953
Required for ArcadiaPower/osprey