### PR TITLE
Rule react/sort-comp "error"

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,47 @@ module.exports = {
     "react/prefer-stateless-function": "off",     // Team Preference
     "react/require-default-props": "off",         // TBD
     "react/self-closing-comp": "off",             // TBD
-    "react/sort-comp": "off",                     // TBD
+    "react/sort-comp": ["error", {                // Team Preference
+      "order": [
+        "static-methods",
+        "/constructor/",
+        "/state/",
+        "instance-variables",
+        "lifecycle",
+        "everything-else",
+        "getters",
+        "render"
+      ],
+      "groups": {
+        "lifecycle": [
+          "childContextTypes",
+          "componentDidCatch",
+          "componentDidMount",
+          "componentDidUpdate",
+          "componentWillMount",
+          "componentWillReceiveProps",
+          "componentWillUnmount",
+          "componentWillUpdate",
+          "constructor",
+          "contextTypes",
+          "defaultProps",
+          "displayName",
+          "getChildContext",
+          "getDefaultProps",
+          "getDerivedStateFromProps",
+          "getInitialState",
+          "getSnapshotBeforeUpdate",
+          "mixins",
+          "propTypes",
+          "shouldComponentUpdate",
+          "state",
+          "statics",
+          "UNSAFE_componentWillMount",
+          "UNSAFE_componentWillReceiveProps",
+          "UNSAFE_componentWillUpdate"
+        ]
+      }
+    }],
 
     "sort-keys": "error",                         // Team Preference
     "space-before-function-paren": "off"          // Team Preference

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-arcadia",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Arcadia Power's ESLint Configuration",
   "main": "index.js",
   "author": "Arcadia Power Engineering",


### PR DESCRIPTION
Turns on the ESLint [rule `react/sort-comp`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md#rule-options) with a custom configuration.

>When creating React components it is more convenient to always follow the same organisation for method order to help you easily find lifecycle methods, event handlers, etc.

As part of The Great Jabiru Reformation arcadiapower/jabiru#888:

>**component methods are properly ordered**
>- group/alphabetize lifecycle methods at the top
>- group/alphabetize handlers and other methods
>- group/alphabetize getters (alphabetizing can be overridden by logical groupings)

**Required** for ArcadiaPower/jabiru#1041