### PR TITLE
ESLint arrow-parens "as-needed" only

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,11 +7,9 @@ module.exports = {
   },
   "rules": {
     "arrow-body-style": "off",                  // Team Preference
-    "arrow-parens": ["error", "as-needed", {    // Team Preference
-        "requireForBlockBody": true
-    }],
-    "class-methods-use-this": "off",    // TBD
-    "comma-dangle": ["error", {         // Team Preference
+    "arrow-parens": ["error", "as-needed"],     // Team Preference
+    "class-methods-use-this": "off",            // TBD
+    "comma-dangle": ["error", {                 // Team Preference
       "arrays": "always-multiline",
       "objects": "always-multiline",
       "imports": "never",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-arcadia",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Arcadia Power's ESLint Configuration",
   "main": "index.js",
   "author": "Arcadia Power Engineering",


### PR DESCRIPTION
## What
Removes `arrow-parens` rule exception `requireForBlockBody`

## How to test
See dependent repos for fixed violations:
- [x] arcadiapower/Peregrine#270
- [x] arcadiapower/Jabiru#1250
- [x] arcadiapower/Osprey#660
- [x] arcadiapower/Shrike#172
- [x] arcadiapower/Gryphon#229

## Why
Closes #8 
Team voted [#eng-frontend](https://arcadiapower.slack.com/archives/CC57LPCP9/p1557241843188200)

## Test Coverage
Tests will fail until `eslint-config-arcadia` is updated

## Risks and Deploy Considerations
Nope
