### PR TITLE
Require trailing commas for imports and exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,8 +12,8 @@ module.exports = {
     "comma-dangle": ["error", {                 // Team Preference
       "arrays": "always-multiline",
       "objects": "always-multiline",
-      "imports": "never",
-      "exports": "never",
+      "imports": "always-multiline",
+      "exports": "always-multiline",
       "functions": "ignore"
     }],
     "consistent-return": "off",         // TBD

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "eslint-config-arcadia",
+  "version": "0.1.0",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-arcadia",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Arcadia Power's ESLint Configuration",
   "main": "index.js",
   "author": "Arcadia Power Engineering",


### PR DESCRIPTION
## What
- Updates [`comma-dangle` rule for imports and exports](https://eslint.org/docs/rules/comma-dangle#options) to `always-multiline`
- Checks in `package-lock`

## Why
Closes #12 

```js
// Bad Cat
import {
  alpha,
  bravo,
  charlie
} from 'foo';

// Good Cat
import {
  alpha,
  bravo,
  charlie,
} from 'foo';
```

## Risks
Once this is approved and merged, all consuming apps have a corresponding PR to update the package version and fix errors:

- ArcadiaPower/jabiru#1528
- ArcadiaPower/peregrine#511
- ArcadiaPower/osprey#1329
- ArcadiaPower/shrike#268
- ArcadiaPower/gryphon#662
- ArcadiaPower/pigeon#738