### PR TITLE
enforce jsx object child spacing

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@ module.exports = {
     "react/forbid-prop-types": "off",             // TBD
     "react/jsx-boolean-value": ["error", "always"],
     "react/jsx-closing-bracket-location": "off",  // TBD --fixable
+    "react/jsx-curly-spacing": ["error", {"when": "always", "attributes": false, "children": true}], // Team Preference
     "react/jsx-no-bind": "off",                   // TBD
     "react/jsx-no-target-blank": "off",           // TBD
     "react/jsx-no-undef": "off",                  // TBD

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "eslint-config-arcadia",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-arcadia",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Arcadia Power's ESLint Configuration",
   "main": "index.js",
   "author": "Arcadia Power Engineering",


### PR DESCRIPTION
## What
Adds jsx object child bracket spacing
Bad:
```<Text className={styles.title}>{this.props.title}</Text>```
Good:
```<Text className={styles.title}>{ this.props.title }</Text>```

## Why
team lint discussion 

